### PR TITLE
20220306 key match style

### DIFF
--- a/mockserver-client-java/pom.xml
+++ b/mockserver-client-java/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver</artifactId>
-        <version>5.12.0</version>
+        <version>5.12.0-msp</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/mockserver-core/pom.xml
+++ b/mockserver-core/pom.xml
@@ -15,6 +15,14 @@
     <url>https://www.mock-server.com</url>
 
     <dependencies>
+        <!-- mockserver-plus源码改动 zhoubh -->
+        <!--mockserver-plus系列-->
+        <dependency>
+            <groupId>com.zhoubh</groupId>
+            <artifactId>mockserver-plus-core</artifactId>
+        </dependency>
+        <!-- mockserver-plus源码改动 zhoubh -->
+
         <!-- mockserver -->
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/mockserver-core/pom.xml
+++ b/mockserver-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver</artifactId>
-        <version>5.12.0</version>
+        <version>5.12.0-msp</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/mockserver-core/pom.xml
+++ b/mockserver-core/pom.xml
@@ -21,6 +21,10 @@
             <groupId>com.zhoubh</groupId>
             <artifactId>mockserver-plus-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.zhoubh</groupId>
+            <artifactId>mockserver-plus-model</artifactId>
+        </dependency>
         <!-- mockserver-plus源码改动 zhoubh -->
 
         <!-- mockserver -->

--- a/mockserver-core/src/main/java/org/mockserver/matchers/HttpRequestPropertiesMatcher.java
+++ b/mockserver-core/src/main/java/org/mockserver/matchers/HttpRequestPropertiesMatcher.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.common.base.Joiner;
 import com.zhoubh.core.util.JsonConvertUtil;
+import com.zhoubh.mock.manager.MockBaseManager;
 import com.zhoubh.mock.manager.MockHandlerManager;
 import org.apache.commons.lang3.StringUtils;
 import org.mockserver.codec.ExpandedParameterDecoder;
@@ -64,15 +65,12 @@ public class HttpRequestPropertiesMatcher extends AbstractHttpRequestMatcher {
     private RegexStringMatcher userMatcher = null;
 
     /**
-     * id的结构是: id.userId
+     * id的结构是: userId.id
      * @param id
      */
     private void withUser(String id) {
-        String[] ids = id.split("\\.");
-        if (ids.length < 2) {
-            return;
-        }
-        this.userMatcher = new RegexStringMatcher(mockServerLogger, NottableString.string(ids[1]), controlPlaneMatcher);
+        String userId = MockBaseManager.getUserId(id);
+        this.userMatcher = new RegexStringMatcher(mockServerLogger, NottableString.string(userId), controlPlaneMatcher);
     }
     /*-------------------- mockserver-plus源码改动 zhoubh --------------------------------------------------------*/
 

--- a/mockserver-core/src/main/java/org/mockserver/matchers/MatchDifference.java
+++ b/mockserver-core/src/main/java/org/mockserver/matchers/MatchDifference.java
@@ -17,6 +17,10 @@ import static org.slf4j.event.Level.TRACE;
 public class MatchDifference {
 
     public enum Field {
+        /*-------------------- mockserver-plus源码改动 zhoubh --------------------------------------------------------*/
+        USER("user"),
+        /*-------------------- mockserver-plus源码改动 zhoubh --------------------------------------------------------*/
+
         METHOD("method"),
         PATH("path"),
         PATH_PARAMETERS("pathParameters"),

--- a/mockserver-core/src/main/java/org/mockserver/mock/HttpState.java
+++ b/mockserver-core/src/main/java/org/mockserver/mock/HttpState.java
@@ -3,7 +3,7 @@ package org.mockserver.mock;
 import com.google.common.annotations.VisibleForTesting;
 import com.zhoubh.mock.manager.MockBaseManager;
 import com.zhoubh.mock.manager.MockRedisManager;
-import com.zhoubh.mock.model.UpdateAction;
+import com.zhoubh.model.mock.UpdateAction;
 import org.mockserver.closurecallback.websocketregistry.WebSocketClientRegistry;
 import org.mockserver.configuration.ConfigurationProperties;
 import org.mockserver.log.MockServerEventLog;
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import static com.zhoubh.mock.model.UpdateAction.*;
+import static com.zhoubh.model.mock.UpdateAction.*;
 import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
 import static io.netty.handler.codec.http.HttpResponseStatus.*;
 import static java.nio.charset.StandardCharsets.UTF_8;

--- a/mockserver-core/src/main/java/org/mockserver/mock/RequestMatchers.java
+++ b/mockserver-core/src/main/java/org/mockserver/mock/RequestMatchers.java
@@ -103,14 +103,17 @@ public class RequestMatchers extends MockServerMatcherNotifier {
 
     /**
      * 根据expectationId移除规则
-     * @param expectationId
+     * @param expectationIds
      * @return
      */
-    public void removeExpectationWithId(String expectationId) {
-        if (Objects.nonNull(expectationId)) {
-            httpRequestMatchers.getByKey(expectationId).
-                ifPresent(httpRequestMatcher -> scheduler.submit(() -> removeHttpRequestMatcher(httpRequestMatcher,
-                    UUIDService.getUUID())));
+    public void removeWithExpectationIds(String... expectationIds) {
+        if (Objects.nonNull(expectationIds) && expectationIds.length > 0) {
+            Arrays.stream(expectationIds).
+                forEach(expectationId -> {
+                    httpRequestMatchers.getByKey(expectationId).
+                        ifPresent(httpRequestMatcher -> scheduler.submit(() -> removeHttpRequestMatcher(httpRequestMatcher,
+                            UUIDService.getUUID())));
+                });
         }
     }
 

--- a/mockserver-core/src/main/java/org/mockserver/mock/RequestMatchers.java
+++ b/mockserver-core/src/main/java/org/mockserver/mock/RequestMatchers.java
@@ -99,6 +99,23 @@ public class RequestMatchers extends MockServerMatcherNotifier {
         return upsertedExpectation;
     }
 
+    /*-------------------- mockserver-plus源码改动 zhoubh --------------------------------------------------------*/
+
+    /**
+     * 根据expectationId移除规则
+     * @param expectationId
+     * @return
+     */
+    public void removeExpectationWithId(String expectationId) {
+        if (Objects.nonNull(expectationId)) {
+            httpRequestMatchers.getByKey(expectationId).
+                ifPresent(httpRequestMatcher -> scheduler.submit(() -> removeHttpRequestMatcher(httpRequestMatcher,
+                    UUIDService.getUUID())));
+        }
+    }
+
+    /*-------------------- mockserver-plus源码改动 zhoubh --------------------------------------------------------*/
+
     public void update(Expectation[] expectations, Cause cause) {
         AtomicInteger numberOfChanges = new AtomicInteger(0);
         if (expectations != null) {

--- a/mockserver-core/src/main/java/org/mockserver/mock/action/http/HttpResponseClassCallbackActionHandler.java
+++ b/mockserver-core/src/main/java/org/mockserver/mock/action/http/HttpResponseClassCallbackActionHandler.java
@@ -1,5 +1,7 @@
 package org.mockserver.mock.action.http;
 
+import com.zhoubh.core.util.ObjectConvertUtil;
+import com.zhoubh.mock.manager.MockHandlerManager;
 import org.mockserver.log.model.LogEntry;
 import org.mockserver.logging.MockServerLogger;
 import org.mockserver.mock.action.ExpectationResponseCallback;
@@ -10,6 +12,7 @@ import org.slf4j.event.Level;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Objects;
 
 import static org.mockserver.model.HttpResponse.notFoundResponse;
 
@@ -49,6 +52,18 @@ public class HttpResponseClassCallbackActionHandler {
                     .setMessageFormat("ClassNotFoundException - while trying to instantiate ExpectationResponseCallback class \"" + httpClassCallback.getCallbackClass() + "\"")
                     .setThrowable(e)
             );
+
+            /*-------------------- mockserver-plus源码改动 zhoubh --------------------------------------------------------*/
+            /**
+             * 只有这个异常才将classCallback认为是脚本代码
+             */
+            Object object = MockHandlerManager.getGroovyResponseCallback(httpClassCallback.getCallbackClass());
+            if (Objects.isNull(object)) {
+                return null;
+            }
+            return ObjectConvertUtil.convert(object, ExpectationResponseCallback.class);
+            /*-------------------- mockserver-plus源码改动 zhoubh --------------------------------------------------------*/
+
         } catch (NoSuchMethodException e) {
             mockServerLogger.logEvent(
                 new LogEntry()

--- a/mockserver-core/src/main/java/org/mockserver/serialization/ExpectationSerializer.java
+++ b/mockserver-core/src/main/java/org/mockserver/serialization/ExpectationSerializer.java
@@ -116,8 +116,12 @@ public class ExpectationSerializer implements Serializer<Expectation> {
                     OPEN_API_SPECIFICATION_URL
             );
         } else {
+            /*-------------------- mockserver-plus源码改动 zhoubh --------------------------------------------------------*/
+            /**
             String validationErrors = getValidator().isValid(jsonExpectation);
             if (validationErrors.isEmpty()) {
+             **/
+             /*-------------------- mockserver-plus源码改动 zhoubh --------------------------------------------------------*/
                 Expectation expectation = null;
                 try {
                     ExpectationDTO expectationDTO = objectMapper.readValue(jsonExpectation, ExpectationDTO.class);
@@ -135,9 +139,13 @@ public class ExpectationSerializer implements Serializer<Expectation> {
                     throw new IllegalArgumentException("exception while parsing [" + jsonExpectation + "] for Expectation", throwable);
                 }
                 return expectation;
+            /*-------------------- mockserver-plus源码改动 zhoubh --------------------------------------------------------*/
+            /**
             } else {
                 throw new IllegalArgumentException(StringUtils.removeEndIgnoreCase(formatLogMessage("incorrect expectation json format for:{}schema validation errors:{}", jsonExpectation, validationErrors), "\n"));
             }
+             **/
+            /*-------------------- mockserver-plus源码改动 zhoubh --------------------------------------------------------*/
         }
     }
 

--- a/mockserver-examples/pom.xml
+++ b/mockserver-examples/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver</artifactId>
-        <version>5.12.0</version>
+        <version>5.12.0-msp</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/mockserver-integration-testing/pom.xml
+++ b/mockserver-integration-testing/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver</artifactId>
-        <version>5.12.0</version>
+        <version>5.12.0-msp</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/mockserver-junit-jupiter/pom.xml
+++ b/mockserver-junit-jupiter/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver</artifactId>
-        <version>5.12.0</version>
+        <version>5.12.0-msp</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/mockserver-junit-rule/pom.xml
+++ b/mockserver-junit-rule/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver</artifactId>
-        <version>5.12.0</version>
+        <version>5.12.0-msp</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/mockserver-netty/pom.xml
+++ b/mockserver-netty/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver</artifactId>
-        <version>5.12.0</version>
+        <version>5.12.0-msp</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/mockserver-proxy-war/pom.xml
+++ b/mockserver-proxy-war/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver</artifactId>
-        <version>5.12.0</version>
+        <version>5.12.0-msp</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/mockserver-spring-test-listener/pom.xml
+++ b/mockserver-spring-test-listener/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver</artifactId>
-        <version>5.12.0</version>
+        <version>5.12.0-msp</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/mockserver-testing/pom.xml
+++ b/mockserver-testing/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver</artifactId>
-        <version>5.12.0</version>
+        <version>5.12.0-msp</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/mockserver-war/pom.xml
+++ b/mockserver-war/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver</artifactId>
-        <version>5.12.0</version>
+        <version>5.12.0-msp</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,8 @@
         <xmlunit.version>2.9.0</xmlunit.version>
 
         <!-- mockserver-plus源码改动 zhoubh -->
-        <mockserverplus.version>1.0</mockserverplus.version>
+        <msp.core.version>1.0</msp.core.version>
+        <msp.model.version>1.0</msp.model.version>
         <!-- mockserver-plus源码改动 zhoubh -->
 
         <skipTests>false</skipTests>
@@ -102,7 +103,12 @@
             <dependency>
                 <groupId>com.zhoubh</groupId>
                 <artifactId>mockserver-plus-core</artifactId>
-                <version>${mockserverplus.version}</version>
+                <version>${msp.core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.zhoubh</groupId>
+                <artifactId>mockserver-plus-model</artifactId>
+                <version>${msp.model.version}</version>
             </dependency>
             <!-- mockserver-plus源码改动 zhoubh -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,13 +60,20 @@
         <netty.version>4.1.74.Final</netty.version>
         <httpcomponents.version>4.4.1</httpcomponents.version>
         <boucycastle.verion>1.70</boucycastle.verion>
-        <spring.version>5.3.15</spring.version>
+
+        <!-- mockserver-plus源码改动 zhoubh -->
+        <!-- 让spring版本和spring-boot中引用的spring版本保持一致 -->
+        <spring.version>5.2.8.RELEASE</spring.version>
+        <!-- mockserver-plus源码改动 zhoubh -->
+
         <mockito.version>4.3.1</mockito.version>
         <hamcrest.version>2.2</hamcrest.version>
         <xmlunit.version>2.9.0</xmlunit.version>
+
         <!-- mockserver-plus源码改动 zhoubh -->
         <mockserverplus.version>1.0</mockserverplus.version>
         <!-- mockserver-plus源码改动 zhoubh -->
+
         <skipTests>false</skipTests>
         <skipAssembly>false</skipAssembly>
         <release.arguments />
@@ -814,6 +821,8 @@
                 </executions>
             </plugin>
             <!-- ensure no implicit transitive dependencies not at the same version -->
+            <!-- mockserver-plus源码改动 zhoubh -->
+            <!--
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
@@ -832,6 +841,7 @@
                     </execution>
                 </executions>
             </plugin>
+            -->
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.mock-server</groupId>
     <artifactId>mockserver</artifactId>
-    <version>5.12.0</version>
+    <version>5.12.0-msp</version>
     <packaging>pom</packaging>
 
     <name>MockServer</name>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,9 @@
         <mockito.version>4.3.1</mockito.version>
         <hamcrest.version>2.2</hamcrest.version>
         <xmlunit.version>2.9.0</xmlunit.version>
+        <!-- mockserver-plus源码改动 zhoubh -->
+        <mockserverplus.version>1.0</mockserverplus.version>
+        <!-- mockserver-plus源码改动 zhoubh -->
         <skipTests>false</skipTests>
         <skipAssembly>false</skipAssembly>
         <release.arguments />
@@ -87,6 +90,15 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- mockserver-plus源码改动 zhoubh -->
+            <!--mockserver-plus系列-->
+            <dependency>
+                <groupId>com.zhoubh</groupId>
+                <artifactId>mockserver-plus-core</artifactId>
+                <version>${mockserverplus.version}</version>
+            </dependency>
+            <!-- mockserver-plus源码改动 zhoubh -->
+
             <!-- mockserver -->
             <dependency>
                 <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
1、redis-key去掉userId；
2、MOCK.UPDATE每次都查询全部的规则出来，不再区分用户去做update；
3、支持headers、queryStringParameters、pathParameters设置keyMatchStyle；
4、依赖mockserver-plus-model，主要是公用的模型；